### PR TITLE
hwids: Add Radxa Dragon Q6A (QCS6490)

### DIFF
--- a/hwids/json/qcs6490-radxa-dragon-q6a.json
+++ b/hwids/json/qcs6490-radxa-dragon-q6a.json
@@ -1,0 +1,20 @@
+{
+    "type": "devicetree",
+    "name": "Radxa Computer Co., Ltd. Dragon Q6A",
+    "compatible": "radxa,dragon-q6a",
+    "hwids": [
+        "828eb813-7088-5b74-91b2-581c71a9e58a",
+        "d46d782d-ed40-5cc5-9cb1-03bd0f1ba1ac",
+        "36dc60d9-36a7-5d6d-b7d1-b20d3b8521c1",
+        "2d18eb8b-fe7a-526b-b913-f3e2d366d8e8",
+        "29510c55-b2ce-5122-bd34-a1c77c64b673",
+        "666a6e3e-73c3-5475-ae55-86606c502318",
+        "46be9463-e0b7-590b-930e-9cde5becde40",
+        "a028d60b-48c4-548a-b5f4-62af53bf2d6a",
+        "a15c852f-9a2d-5055-83e4-0cf58c783552",
+        "0b164575-51b1-5f88-98ac-6f0ead016657",
+        "2dc5be40-2527-5768-8b7a-da028d4a72a8",
+        "7442b08a-7f48-5799-9455-cae343e65d05",
+        "933f1601-f12d-5db0-b3f2-e949e5cb25ef"
+    ]
+}

--- a/hwids/txt/qcs6490-radxa-dragon-q6a.txt
+++ b/hwids/txt/qcs6490-radxa-dragon-q6a.txt
@@ -1,0 +1,35 @@
+Computer Information
+--------------------
+BiosVendor: Qualcomm Technologies, Inc.
+BiosVersion: 6.0.260120.BOOT.MXF.1.0.1-00549-KODIAKWP-1
+BiosMajorRelease: 255
+BiosMinorRelease: 255
+FirmwareMajorRelease: ff
+FirmwareMinorRelease: ff
+Manufacturer: Radxa Computer Co., Ltd.
+Family: Dragon
+ProductName: Radxa Dragon Q6A
+ProductSku: Q6A
+EnclosureKind: 23
+BaseboardManufacturer: Radxa Computer Co., Ltd.
+BaseboardProduct: Radxa Dragon Q6A
+Hardware IDs
+------------
+{828eb813-7088-5b74-91b2-581c71a9e58a}   <- Manufacturer + Family + ProductName + ProductSku + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
+{d46d782d-ed40-5cc5-9cb1-03bd0f1ba1ac}   <- Manufacturer + Family + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
+{36dc60d9-36a7-5d6d-b7d1-b20d3b8521c1}   <- Manufacturer + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
+{2d18eb8b-fe7a-526b-b913-f3e2d366d8e8}   <- Manufacturer + Family + ProductName + ProductSku + BaseboardManufacturer + BaseboardProduct
+{29510c55-b2ce-5122-bd34-a1c77c64b673}   <- Manufacturer + Family + ProductName + ProductSku
+{666a6e3e-73c3-5475-ae55-86606c502318}   <- Manufacturer + Family + ProductName
+{46be9463-e0b7-590b-930e-9cde5becde40}   <- Manufacturer + ProductSku + BaseboardManufacturer + BaseboardProduct
+{a028d60b-48c4-548a-b5f4-62af53bf2d6a}   <- Manufacturer + ProductSku
+{a15c852f-9a2d-5055-83e4-0cf58c783552}   <- Manufacturer + ProductName + BaseboardManufacturer + BaseboardProduct
+{0b164575-51b1-5f88-98ac-6f0ead016657}   <- Manufacturer + ProductName
+{2dc5be40-2527-5768-8b7a-da028d4a72a8}   <- Manufacturer + Family + BaseboardManufacturer + BaseboardProduct
+{140458e4-2adc-5d37-bee0-829fd1934ac4}   <- Manufacturer + Family
+{7dcb823c-285e-5ff9-9e0b-2e40c6fed75c}   <- Manufacturer + EnclosureKind
+{58c74452-e199-5efd-8c6f-0e5ec2f8ae6e}   <- Manufacturer + BaseboardManufacturer + BaseboardProduct
+{96f77c3b-fa27-55f1-a319-7c337b839961}   <- Manufacturer
+{7442b08a-7f48-5799-9455-cae343e65d05}   <- Manufacturer + Family + ProductName + ProductSku + BiosVendor
+{933f1601-f12d-5db0-b3f2-e949e5cb25ef}   <- Manufacturer + Family + ProductName + BiosVendor
+{c0dbe9b8-6364-5274-be07-3a47c401c75b}   <- Manufacturer + BiosVendor


### PR DESCRIPTION
hwids from: https://github.com/TravMurav/dtbloader/commit/b1a0696 + updated further with https://github.com/TravMurav/dtbloader/commit/493e7e8
upstream: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/arm64/boot/dts/qcom/qcs6490-radxa-dragon-q6a.dts?h=linux-6.19.y
I don't have the board but just syncing missing stuff from dtbloader side, to be tested by someone with hw :)