### PR TITLE
Support building on riscv64

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -22,7 +22,9 @@ LDFLAGS += -z noexecstack
 LDFLAGS += -z relro
 LDFLAGS += -z separate-code
 LDFLAGS += $(shell $(CC) -print-libgcc-file-name)
-LDFLAGS += -Wl,-z,nopack-relative-relocs
+ifneq ($(ARCH),riscv64)
+	LDFLAGS += -Wl,-z,nopack-relative-relocs
+endif
 LDFLAGS += -fcf-protection=none
 LDFLAGS += -fno-asynchronous-unwind-tables
 LDFLAGS += -fno-exceptions -fno-unwind-tables

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-include ./Make.defaults
-
 ARCH?=		$(shell uname -m)
 PREFIX?=	/usr
+
+include ./Make.defaults
 
 ifeq ($(ARCH),x86_64)
 	CFLAGS += -m64 -march=x86-64 -mno-red-zone -mgeneral-regs-only -maccumulate-outgoing-args


### PR DESCRIPTION
Correct build flags for riscv64
    
nopack-relative-relocs is an x86 specific linker option.
On riscv64 it results in an error:

    /usr/bin/ld: error: unsupported option: -z nopack-relative-relocs

Remove the linker flag on this architecture.