### PR TITLE
Makefile: raise minimum number of sections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 ARCH?=		$(shell uname -m)
 PREFIX?=	/usr
+MIN_SECTIONS?=2048
 
 include ./Make.defaults
 
@@ -26,7 +27,7 @@ all: stubble.efi
 stubble.efi: stubble
 	./elf2efi.py --version-major=6 --version-minor=16 \
 	    --efi-major=1 --efi-minor=1 --subsystem=10 \
-	    --minimum-sections=50 \
+	    --minimum-sections=${MIN_SECTIONS} \
 	    --copy-sections=".sbat" $< $@
 
 stubble: $(OBJS)


### PR DESCRIPTION
50 sections is not enough for all arm64 device-trees. Ubuntu currently packages 1456 dtbs in kernel 6.17. 2048 sections should be enough for the near future.

Add an environment variable MIN_SECTIONS that can be used to override the default.