### PR TITLE
Rename dtb_override to dtb_autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ If a match is found it loads the corresponding device tree from the
 ## Command-line parameters
 
 - `debug`: Enable debug logging
-- `stubble.dtb_override=true/false`: Enable or disable device-tree compat based dtb lookup. The default is `true`.
+- `stubble.dtb_autodetect=true/false`: Enable or disable device-tree compat based dtb lookup. The default is `true`.
+- `stubble.dtb_override=true/false`: Deprecated, same as stubble.dtb_autodetect. Kept for backward compatability.
 
 ## Dependencies
 

--- a/include/pe.h
+++ b/include/pe.h
@@ -3,7 +3,7 @@
 
 #include "efi.h"
 
-extern bool dtb_override;
+extern bool dtb_autodetect;
 
 /* This is the actual PE format of the section header */
 typedef struct PeSectionHeader {

--- a/pe.c
+++ b/pe.c
@@ -35,7 +35,7 @@
 #  define TARGET_MACHINE_TYPE_COMPATIBILITY 0
 #endif
 
-bool dtb_override = true;
+bool dtb_autodetect = true;
 
 typedef struct DosFileHeader {
         uint8_t  Magic[2];
@@ -205,7 +205,7 @@ static bool pe_use_this_dtb(
 
         EFI_STATUS err;
 
-        if (dtb_override == true) {
+        if (dtb_autodetect == true) {
                 err = devicetree_match(dtb, dtb_size);
                 if (err == EFI_SUCCESS) {
                         log_debug("found device-tree based on compatible: %s",

--- a/stub.c
+++ b/stub.c
@@ -24,18 +24,21 @@ static bool parse_string(char16_t *p, const char16_t *opt) {
 }
 
 static void parse_cmdline(char16_t *p) {
-        if(p == NULL)
+        if (p == NULL)
                 return;
         while (*p != '\0') {
                 if (parse_string(p, L"debug")) {
                         log_isdebug = true;
-                } else if (strncmp16(p, L"stubble.dtb_override=",
+                } else if (strncmp16(p, L"stubble.dtb_autodetect=",
+                                        strlen16(L"stubble.dtb_autodetect=")) == 0 ||
+                           strncmp16(p, L"stubble.dtb_override=",
                                         strlen16(L"stubble.dtb_override=")) == 0) {
-                        p += strlen16(L"stubble.dtb_override=");
+                        p = strchr16(p, '=');
+                        p++;
                         if (parse_string(p, L"true")) {
-                                dtb_override = true;
+                                dtb_autodetect = true;
                         } else if (parse_string(p, L"false")) {
-                                dtb_override = false;
+                                dtb_autodetect = false;
                         }
                 }
                 p = strchr16(p, ' ');
@@ -170,7 +173,7 @@ static EFI_STATUS run(EFI_HANDLE image) {
         if (log_isdebug == true) {
                 log_debug("Stubble configuration:");
                 log_debug("debug: enabled");
-                log_debug("dtb_override: %s", dtb_override ? "enabled" : "disabled");
+                log_debug("dtb_autodetect: %s", dtb_autodetect ? "enabled" : "disabled");
         }
 
         /* Find the sections we want to operate on */


### PR DESCRIPTION
This ambiguity has caused confusion, for example in https://discourse.ubuntu.com/t/faq-ubuntu-25-04-25-10-on-snapdragon-x-elite/61016/112 , `dtb_override=true` was suggested when `false` was actually required to load a custom device tree.