### PR TITLE
Correct function devicetree_get_compatible()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ endif
 OBJS = devicetree.o efi-log.o efi-efivars.o efi-string.o linux.o stub.o util.o uki.o smbios.o initrd.o \
 	pe.o chid.o edid.o secure-boot.o sha1.o measure.o
 
-.PHONY: all clean install
+TEST_CFLAGS = -I include -DRELATIVE_SOURCE_PATH="\".\"" -ffreestanding -fshort-wchar -fno-strict-aliasing -O2 -ffunction-sections -fdata-sections
+TEST_LDFLAGS = -Wl,--gc-sections
+
+.PHONY: all check clean install
 
 all: stubble.efi
 
@@ -39,7 +42,23 @@ install: stubble.efi
 	install -m 755 -d ${DESTDIR}${PREFIX}/share/stubble/hwids
 	install -m 644 -t ${DESTDIR}${PREFIX}/share/stubble/hwids hwids/json/*
 
+test/data/test-devicetree_get_compatible.dtb: test/data/test-devicetree_get_compatible.dts
+	dtc -I dts -O dtb -o $@ $<
+
+test/data/test-devicetree_get_compatible-child-only.dtb: test/data/test-devicetree_get_compatible-child-only.dts
+	dtc -I dts -O dtb -o $@ $<
+
+test/test-devicetree_get_compatible: test/test-devicetree_get_compatible.c devicetree.c
+	$(CC) $(TEST_CFLAGS) -o $@ $^ $(TEST_LDFLAGS)
+
+check: test/test-devicetree_get_compatible \
+	test/data/test-devicetree_get_compatible.dtb \
+	test/data/test-devicetree_get_compatible-child-only.dtb
+	$< $(word 2,$^) $(word 3,$^)
+
 clean:
 	rm -f $(OBJS)
 	rm -f stubble
 	rm -f stubble.efi
+	rm -f test/test-devicetree_get_compatible
+	rm -f test/data/*.dtb

--- a/devicetree.c
+++ b/devicetree.c
@@ -97,7 +97,7 @@ const char* devicetree_get_compatible(const void *dtb) {
         size_t size_words = struct_size / sizeof(uint32_t);
         size_t len, name_off, len_words, s;
 
-        for (size_t i = 0; i < end; i++) {
+        for (size_t i = 0; i < size_words; i++) {
                 switch (be32toh(cursor[i])) {
                 case FDT_BEGIN_NODE:
                         if (i >= size_words || cursor[++i] != 0)

--- a/devicetree.c
+++ b/devicetree.c
@@ -96,33 +96,54 @@ const char* devicetree_get_compatible(const void *dtb) {
 
         size_t size_words = struct_size / sizeof(uint32_t);
         size_t len, name_off, len_words, s;
+        int level = -1;
 
         for (size_t i = 0; i < size_words; i++) {
                 switch (be32toh(cursor[i])) {
                 case FDT_BEGIN_NODE:
-                        if (i >= size_words || cursor[++i] != 0)
+                        if (++i >= size_words)
                                 return NULL;
+
+                        for (;; i++) {
+                                if (i >= size_words)
+                                        return NULL;
+                                if (memchr(&cursor[i], 0, sizeof(uint32_t)))
+                                        break;
+                        }
+
+                        level++;
+                        break;
+                case FDT_END_NODE:
+                        if (level < 0)
+                                return NULL;
+
+                        level--;
                         break;
                 case FDT_NOP:
                         break;
                 case FDT_PROP:
                         /* At least 3 words should present: len, name_off, c (nul-terminated string always has non-zero length) */
-                        if (i + 3 >= size_words)
+                        if (level < 0 || i + 3 >= size_words)
                                 return NULL;
                         len = be32toh(cursor[++i]);
                         name_off = be32toh(cursor[++i]);
                         len_words = DIV_ROUND_UP(len, sizeof(uint32_t));
 
-                        if (ADD_SAFE(&s, name_off, STRLEN("compatible")) &&
+                        if (level == 0 &&
+                            ADD_SAFE(&s, name_off, STRLEN("compatible")) &&
                             s < strings_size && streq8(strings_block + name_off, "compatible")) {
-                                const char *c = (const char *) &cursor[++i];
-                                if (len == 0 || i + len_words > size_words || c[len - 1] != '\0')
-                                        c = NULL;
+                                const char *c = (const char *) &cursor[i + 1];
+
+                                if (len == 0 || i + len_words >= size_words || c[len - 1] != '\0')
+                                        return NULL;
 
                                 return c;
                         }
+
                         i += len_words;
                         break;
+                case FDT_END:
+                        return NULL;
                 default:
                         return NULL;
                 }

--- a/test/data/test-devicetree_get_compatible-child-only.dts
+++ b/test/data/test-devicetree_get_compatible-child-only.dts
@@ -1,0 +1,7 @@
+/dts-v1/;
+
+/ {
+	child-node {
+		compatible = "stubble,child-only";
+	};
+};

--- a/test/data/test-devicetree_get_compatible.dts
+++ b/test/data/test-devicetree_get_compatible.dts
@@ -1,0 +1,9 @@
+/dts-v1/;
+
+/ {
+	compatible = "stubble,test-root", "stubble,test-soc";
+
+	child-node {
+		compatible = "stubble,wrong-child";
+	};
+};

--- a/test/test-devicetree_get_compatible.c
+++ b/test/test-devicetree_get_compatible.c
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+/**
+ * DOC: devicetree_get_compatible() regression test
+ *
+ * This host-side test exercises devicetree_get_compatible() with one DTB that
+ * carries a root compatible property and one DTB that only carries a child node
+ * compatible property.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "devicetree.h"
+
+EFI_BOOT_SERVICES *BS;
+
+_noreturn_ void efi_assert(const char *expr, const char *file, unsigned line, const char *function) {
+        fprintf(stderr, "%s:%u: %s: Assertion '%s' failed\n", file, line, function, expr);
+        abort();
+}
+
+int strncmp8(const char *s1, const char *s2, size_t n) {
+        return strncmp(s1, s2, n);
+}
+
+void *find_configuration_table(const EFI_GUID *guid) {
+        (void) guid;
+        return NULL;
+}
+
+/**
+ * read_file() - Read a file into a newly allocated buffer
+ * @path: path to the file to load
+ * @ret_size: returns the size of the loaded file in bytes
+ *
+ * Return: a malloc()'d buffer containing the file contents.
+ */
+static void *read_file(const char *path, size_t *ret_size) {
+        FILE *f = fopen(path, "rb");
+        void *buffer;
+        long size;
+
+        if (!f) {
+                fprintf(stderr, "failed to open %s: %s\n", path, strerror(errno));
+                exit(EXIT_FAILURE);
+        }
+
+        if (fseek(f, 0, SEEK_END) != 0) {
+                fprintf(stderr, "failed to seek %s: %s\n", path, strerror(errno));
+                fclose(f);
+                exit(EXIT_FAILURE);
+        }
+
+        size = ftell(f);
+        if (size < 0) {
+                fprintf(stderr, "failed to size %s: %s\n", path, strerror(errno));
+                fclose(f);
+                exit(EXIT_FAILURE);
+        }
+
+        if (fseek(f, 0, SEEK_SET) != 0) {
+                fprintf(stderr, "failed to rewind %s: %s\n", path, strerror(errno));
+                fclose(f);
+                exit(EXIT_FAILURE);
+        }
+
+        buffer = malloc((size_t) size);
+        if (!buffer) {
+                fprintf(stderr, "failed to allocate %ld bytes\n", size);
+                fclose(f);
+                exit(EXIT_FAILURE);
+        }
+
+        if (fread(buffer, 1, (size_t) size, f) != (size_t) size) {
+                fprintf(stderr, "failed to read %s\n", path);
+                free(buffer);
+                fclose(f);
+                exit(EXIT_FAILURE);
+        }
+
+        fclose(f);
+        *ret_size = (size_t) size;
+        return buffer;
+}
+
+/**
+ * check_compatible() - Validate the root compatible property of a DTB fixture
+ * @path: path to the DTB file to inspect
+ * @expected: expected root compatible string, or %NULL if no root property
+ *            should be found
+ *
+ * Return: %EXIT_SUCCESS on success, %EXIT_FAILURE on mismatch or parse failure.
+ */
+static int check_compatible(const char *path, const char *expected) {
+        const char *compatible;
+        size_t dtb_size;
+        void *dtb;
+
+        dtb = read_file(path, &dtb_size);
+        if (dtb_size < sizeof(FdtHeader)) {
+                fprintf(stderr, "%s is too small to contain an FDT header\n", path);
+                free(dtb);
+                return EXIT_FAILURE;
+        }
+
+        compatible = devicetree_get_compatible(dtb);
+
+        if (!expected) {
+                if (compatible) {
+                        fprintf(stderr, "%s: expected NULL, got %s\n", path, compatible);
+                        free(dtb);
+                        return EXIT_FAILURE;
+                }
+
+                free(dtb);
+                return EXIT_SUCCESS;
+        }
+
+        if (!compatible) {
+                fprintf(stderr, "%s: devicetree_get_compatible() returned NULL\n", path);
+                free(dtb);
+                return EXIT_FAILURE;
+        }
+
+        if (strcmp(compatible, expected) != 0) {
+                fprintf(stderr, "%s: expected %s, got %s\n", path, expected, compatible);
+                free(dtb);
+                return EXIT_FAILURE;
+        }
+
+        free(dtb);
+        return EXIT_SUCCESS;
+}
+
+/**
+ * main() - Exercise devicetree_get_compatible() on positive and negative cases
+ * @argc: number of command line arguments
+ * @argv: command line arguments, root DTB followed by child-only DTB
+ *
+ * Return: %EXIT_SUCCESS if both fixtures behave as expected, %EXIT_FAILURE
+ * otherwise.
+ */
+int main(int argc, char **argv) {
+        if (argc != 3) {
+                fprintf(stderr, "usage: %s ROOT-DTB CHILD-ONLY-DTB\n", argv[0]);
+                return EXIT_FAILURE;
+        }
+
+        if (check_compatible(argv[1], "stubble,test-root") != EXIT_SUCCESS)
+                return EXIT_FAILURE;
+
+        return check_compatible(argv[2], NULL);
+}


### PR DESCRIPTION
* devicetree_get_compatible() does not correctly detect the end of the device-tree.
* devicetree_get_compatible() will return a compatible property from a child node if no /compatible property exists

Fix the above and add a test.