### PR TITLE
Make.defaults: correct build flags for aarch64 with old gcc

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -24,7 +24,7 @@ LDFLAGS += -z noexecstack
 LDFLAGS += -z relro
 LDFLAGS += -z separate-code
 LDFLAGS += $(shell $(CC) -print-libgcc-file-name)
-ifneq ($(ARCH),riscv64)
+ifneq ($(filter-out riscv64 aarch64,$(ARCH)),)
 	LDFLAGS += -Wl,-z,nopack-relative-relocs
 endif
 LDFLAGS += -fcf-protection=none


### PR DESCRIPTION
nopack-relative-relocs is an x86 specific linker option. On aarch64 with gcc 13 in ubuntu noble it results in an warning and build failed:

    warning: -z nopack-relative-relocs ignored

So filter out both aarch64 and riscv64 for these flags.