### PR TITLE
elf2efi: Fix section overlap caused by per-section align_down

### DIFF
--- a/elf2efi.py
+++ b/elf2efi.py
@@ -324,8 +324,18 @@ def convert_sections(elf: ELFFile, opt: PeOptionalHeader) -> typing.List[PeSecti
         # The ELF sections inside should also be properly aligned as we reuse the ELF VMA layout
         # for the PE image.
         vma = pe_s.VirtualAddress
-        pe_s.VirtualAddress = align_down(vma, SECTION_ALIGNMENT)
-        pe_s.data = bytearray(vma - pe_s.VirtualAddress) + pe_s.data
+        # First section: align down. Subsequent sections: align up from previous end
+        # to avoid overlaps. The original code could cause section overlaps with
+        # older binutils versions.
+        if last_vma == (0, 0):
+            pe_s.VirtualAddress = align_down(vma, SECTION_ALIGNMENT)
+        else:
+            pe_s.VirtualAddress = align_to(sum(last_vma), SECTION_ALIGNMENT)
+        # Add padding as needed
+        if pe_s.VirtualAddress <= vma:
+            pe_s.data = bytearray(vma - pe_s.VirtualAddress) + pe_s.data
+        else:
+            pe_s.data = bytearray(pe_s.VirtualAddress - vma) + pe_s.data
 
         pe_s.VirtualSize = len(pe_s.data)
         pe_s.SizeOfRawData = align_to(len(pe_s.data), FILE_ALIGNMENT)


### PR DESCRIPTION
Instead of aligning every section down independently (which may cause overlaps with older binutils), align subsequent sections up from the previous section's end. Properly handle padding for both align_down and align_up cases.

I have encountered overlap issues when building on a ubuntu noble machine(binutils version is 2.42-4ubuntu2.10). After this fix I can build bootable kernel image with stubble.