### PR TITLE
Add machdb.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ install: stubble.efi stubblify
 	install -m 644 -t ${DESTDIR}${PREFIX}/lib/stubble stubble.efi
 	install -m 755 -d ${DESTDIR}${PREFIX}/share/stubble/hwids
 	install -m 644 -t ${DESTDIR}${PREFIX}/share/stubble/hwids hwids/json/*
+	install -m 644 -t ${DESTDIR}${PREFIX}/share/stubble machdb.txt
 
 clean:
 	rm -f $(OBJS)

--- a/machdb.txt
+++ b/machdb.txt
@@ -1,0 +1,11 @@
+Model: spacemit k3_com260_ifx board
+Compatible: spacemit,k3-com260-ifx
+
+Model: spacemit k3 com260 ifx board
+Compatible: spacemit,k3-com260-ifx
+
+Model: spacemit k3-deepcomputing-fml13v05 board
+Compatible: deepcomputing,fml13v05
+
+Model: spacemit k3-pico-itx board
+Compatible: spacemit,k3-pico-itx


### PR DESCRIPTION
Add a file with mappings of the /model property to the /compatible property. This file can be used with the --machdb parameter of stubblify.